### PR TITLE
Use std=gnu89, the gcc 4.8 default

### DIFF
--- a/src/occApplet/productApplet/Makefile
+++ b/src/occApplet/productApplet/Makefile
@@ -71,7 +71,7 @@ DEFS += -DUSE_SSX_APP_CFG_H=1
 
 # Note: Do not use SDA sections for product applets
 GCC-CFLAGS = -c -g -Wall -fsigned-char -msoft-float -pipe \
--Wa,-m405 -mbig-endian -m32 -mcpu=405 -mmultiple -mstring -meabi -ffreestanding -Os -mno-sdata
+-Wa,-m405 -mbig-endian -m32 -mcpu=405 -mmultiple -mstring -meabi -ffreestanding -Os -mno-sdata -std=gnu89
 
 #*******************************************************************************
 # Compilation

--- a/src/occApplet/testApplet/Makefile
+++ b/src/occApplet/testApplet/Makefile
@@ -64,7 +64,7 @@ DEFS += -DOCC=1 -DUSE_SSX_APP_CFG_H=1
 
 GCC-CFLAGS = -c -g -Wall -fsigned-char -msoft-float -pipe \
 -m32 -mbig-endian -Wa,-m405 -mcpu=405 -mmultiple -mstring -meabi \
--ffreestanding -Os -mno-sdata 
+-ffreestanding -Os -mno-sdata -std=gnu89
 
 #*******************************************************************************
 # Compilation 

--- a/src/ssx/pgp/ssx.mk
+++ b/src/ssx/pgp/ssx.mk
@@ -154,12 +154,12 @@ INCLUDES += $(APP_INCLUDES) \
 	-I$(SSX)/pgp -I$(SSX)/pgp/registers \
 	-I$(LIB)
 
-PIPE-CFLAGS = -pipe -Wa,-m405
+PIPE-CFLAGS = -pipe -Wa,-m405 -std=gnu89
 
 GCC-CFLAGS += -g -Wall -fsigned-char -msoft-float  \
 	-m32 -mbig-endian -mcpu=405 -mmultiple -mstring \
 	-meabi -msdata=eabi -ffreestanding -fno-common \
-	-fno-inline-functions-called-once
+	-fno-inline-functions-called-once -std=gnu89
 
 CFLAGS      =  -c $(GCC-CFLAGS) $(PIPE-CFLAGS) $(GCC-O-LEVEL) $(INCLUDES) 
 PORE-CFLAGS =  -E $(GCC-CFLAGS) $(OPT) $(INCLUDES) 


### PR DESCRIPTION
According to https://gcc.gnu.org/gcc-5/porting_to.html GCC 5
changed to defaulting to -std=gnu11 rather than -std=gnu89, which
causes build failures with OCC code use of 'extern inline'.

so, to work around this, and to stay on a more predictable path,
explicitly set the standard to gnu89.

Fixes: https://github.com/open-power/occ/issues/8
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/occ/15)
<!-- Reviewable:end -->
