### PR TITLE
Use gnu89 as C std

### DIFF
--- a/src/occBootLoader/img_defs.mk
+++ b/src/occBootLoader/img_defs.mk
@@ -226,7 +226,7 @@ PIPE-CFLAGS = -pipe -Wa,-m405
 GCC-CFLAGS += -g -Wall -fsigned-char -msoft-float  \
 	-m32 -mbig-endian -mcpu=405 -mmultiple -mstring \
 	-meabi -msdata=eabi -ffreestanding -fno-common \
-	-fno-inline-functions-called-once
+	-fno-inline-functions-called-once -std=gnu89
 
 CFLAGS      =  -c $(GCC-CFLAGS) $(PIPE-CFLAGS) $(GCC-O-LEVEL) $(INCLUDES)
 

--- a/src/occ_405/img_defs.mk
+++ b/src/occ_405/img_defs.mk
@@ -252,7 +252,7 @@ PIPE-CFLAGS = -pipe -Wa,-m405
 GCC-CFLAGS += -g -Wall -fsigned-char -msoft-float  \
 	-m32 -mbig-endian -mcpu=405 -mmultiple -mstring \
 	-meabi -msdata=eabi -ffreestanding -fno-common \
-	-fno-inline-functions-called-once
+	-fno-inline-functions-called-once -std=gnu89
 
 CFLAGS      =  -c $(GCC-CFLAGS) $(PIPE-CFLAGS) $(GCC-O-LEVEL) $(INCLUDES)
 


### PR DESCRIPTION
This is the same as 72544469d2e83fca6d7ef20a01661a6710077c3b which
never made its way into the P9 branch

Change-Id: I1953f9762f6e3c0f1b8005977de69802f0e11934
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/occ/17)
<!-- Reviewable:end -->
