### PR TITLE
Fix build failure on GCC8

### DIFF
--- a/src/occBootLoader/img_defs.mk
+++ b/src/occBootLoader/img_defs.mk
@@ -226,7 +226,8 @@ PIPE-CFLAGS = -pipe -Wa,-m405
 GCC-CFLAGS += -g -Wall -fsigned-char -msoft-float  \
 	-m32 -mbig-endian -mcpu=405 -mmultiple -mstring \
 	-meabi -msdata=eabi -ffreestanding -fno-common \
-	-fno-inline-functions-called-once -std=gnu89
+	-fno-inline-functions-called-once \
+	-fno-asynchronous-unwind-tables -std=gnu89
 
 CFLAGS      =  -c $(GCC-CFLAGS) $(PIPE-CFLAGS) $(GCC-O-LEVEL) $(INCLUDES)
 

--- a/src/occ_405/img_defs.mk
+++ b/src/occ_405/img_defs.mk
@@ -253,7 +253,8 @@ PIPE-CFLAGS = -pipe -Wa,-m405
 GCC-CFLAGS += -g -Wall -fsigned-char -msoft-float  \
 	-m32 -mbig-endian -mcpu=405 -mmultiple -mstring \
 	-meabi -msdata=eabi -ffreestanding -fno-common \
-	-fno-inline-functions-called-once -std=gnu89
+	-fno-inline-functions-called-once \
+	-fno-asynchronous-unwind-tables -std=gnu89
 
 CFLAGS      =  -c $(GCC-CFLAGS) $(PIPE-CFLAGS) $(GCC-O-LEVEL) $(INCLUDES)
 

--- a/src/occ_gpe0/img_defs.mk
+++ b/src/occ_gpe0/img_defs.mk
@@ -209,6 +209,7 @@ GCC-CFLAGS += -msdata=eabi
 GCC-CFLAGS += -ffreestanding
 GCC-CFLAGS += -fno-common
 GCC-CFLAGS += -fno-inline-functions-called-once
+GCC-CFLAGS += -fno-asynchronous-unwind-tables
 
 CFLAGS      =  -c -std=gnu89 $(GCC-CFLAGS) $(PIPE-CFLAGS) $(GCC-O-LEVEL) $(INCLUDES)
 

--- a/src/occ_gpe1/img_defs.mk
+++ b/src/occ_gpe1/img_defs.mk
@@ -216,6 +216,7 @@ GCC-CFLAGS += -meabi
 GCC-CFLAGS += -ffreestanding
 GCC-CFLAGS += -fno-common
 GCC-CFLAGS += -fno-inline-functions-called-once
+GCC-CFLAGS += -fno-asynchronous-unwind-tables
 GCC-CFLAGS += -std=gnu89
 
 CFLAGS      =  -c $(GCC-CFLAGS) $(PIPE-CFLAGS) $(GCC-O-LEVEL) $(INCLUDES)


### PR DESCRIPTION
When upgrading to GCC8, an .eh_frame section is automatically added.
This consumes too much space in the relatively small OCC address map,
leading to compilation failure.

Pass -fno-asynchronous-unwind-tables to GCC to disable .eh_frame
section generation.