### PR TITLE
Modify amec apss power value calculation

### DIFF
--- a/src/occ_405/amec/amec_sensors_power.c
+++ b/src/occ_405/amec/amec_sensors_power.c
@@ -173,14 +173,18 @@ uint32_t amec_value_from_apss_adc(uint8_t i_chan)
         // Read Raw Value in mA (divide masked channel data by 2)
         l_raw = (G_dcom_slv_inbox_rx.adc[i_chan] & APSS_12BIT_ADC_MASK)/2;
         // Apply offset and gain
-        if (l_offset & 0x80000000)
+        // Add offset if Raw Value is not zero
+	if (l_raw != 0)
         {
-            // Negative offset
-            l_raw -= (~l_offset + 1);
-        }
-        else
-        {
-            l_raw += l_offset;
+            if (l_offset & 0x80000000)
+            {
+                // Negative offset
+                l_raw -= (~l_offset + 1);
+	    }
+	    else
+            {
+                l_raw += l_offset;
+            }
         }
         //Check to see if l_raw is negative.  If so, set raw to 0
         if (l_raw & 0x8000)


### PR DESCRIPTION
If the apss raw data is zero and the adc channel offset is greater than zero, the power value will end up a positive value. In this situation, the total power reading is greater than the actual reading.