### PR TITLE
P8 build fixes for modern GCC

### DIFF
--- a/src/occApplet/productApplet/linkProductApplet.cmd
+++ b/src/occApplet/productApplet/linkProductApplet.cmd
@@ -73,4 +73,7 @@ SECTIONS
 
    __WRITEABLE_DATA_LEN__ = . - __WRITEABLE_DATA_ADDR__;
 
+    /DISCARD/ : {
+       *(.eh_frame)
+    }
 }

--- a/src/occBootLoader/linkboot.cmd
+++ b/src/occBootLoader/linkboot.cmd
@@ -129,4 +129,9 @@ SECTIONS
     // writeable section length
     ////////////////////////////////
    __WRITEABLE_DATA_LEN__ = (__WRITEABLE_ADDR__ + SIZEOF(.sdata) + SIZEOF(.rela) + SIZEOF(.rwdata)) - __WRITEABLE_ADDR__;
+
+    /DISCARD/ : {
+       *(.eh_frame)
+    }
+
 }


### PR DESCRIPTION
Newer linkers generate eh_frame sections. From the ld manual:

 Request creation of ".eh_frame" unwind info for linker generated code sections like PLT.

I do not believe these are used by the OCC, so they can be discarded.
This is what the Linux kernel does too.

Signed-off-by: Joel Stanley <joel@jms.id.au>