### PR TITLE
Fix compilation errors with GCC 9 or newer

### DIFF
--- a/src/occBootLoader/img_defs.mk
+++ b/src/occBootLoader/img_defs.mk
@@ -227,7 +227,7 @@ PIPE-CFLAGS = -pipe -Wa,-m405
 GCC-CFLAGS += -g -Wall -fsigned-char -msoft-float  \
 	-m32 -mbig-endian -mcpu=405 -mmultiple -mstring \
 	-meabi -msdata=eabi -ffreestanding -fno-common \
-	-fno-inline-functions-called-once \
+	-fno-inline-functions-called-once -fno-pic \
 	-fno-asynchronous-unwind-tables -std=gnu89
 
 CFLAGS      =  -c $(GCC-CFLAGS) $(PIPE-CFLAGS) $(GCC-O-LEVEL) $(INCLUDES)

--- a/src/occ_405/img_defs.mk
+++ b/src/occ_405/img_defs.mk
@@ -255,6 +255,9 @@ GCC-CFLAGS += -g -Wall -fsigned-char -msoft-float  \
 	-m32 -mbig-endian -mcpu=405 -mmultiple -mstring \
 	-meabi -msdata=eabi -ffreestanding -fno-common \
 	-fno-inline-functions-called-once \
+	-fno-pic -fno-stack-protector \
+	-Wno-address-of-packed-member \
+	-Wno-array-bounds \
 	-fno-asynchronous-unwind-tables -std=gnu89
 
 CFLAGS      =  -c $(GCC-CFLAGS) $(PIPE-CFLAGS) $(GCC-O-LEVEL) $(INCLUDES)


### PR DESCRIPTION
## Context

Fixes #33 

This would allow us to bump buildroot to 2022.02 or 2023.02

## Changes

* Add `-fno-pic` flag to disable PIC
* Add `-fno-stack-protector` flag to fix issue undefined `__stack_chk_fail`
* Add `-Wno-address-of-packed-member` flag
* Add `-Wno-array-bounds` flag