### PR TITLE
common_types: don't typedef bool on C23 compilers

### DIFF
--- a/src/occ_405/incl/common_types.h
+++ b/src/occ_405/incl/common_types.h
@@ -44,8 +44,8 @@ typedef unsigned long ULONG;
 typedef int           INT;
 typedef void          VOID;
 
-// Skip this typedef in x86 environment
-#if !defined(OCC_X86_PARSER) && !defined(__cplusplus)
+// Skip this typedef in x86 environment, and on C23+ where bool is a builtin keyword
+#if !defined(OCC_X86_PARSER) && !defined(__cplusplus) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L)
 typedef uint8_t       bool;
 #endif
 


### PR DESCRIPTION
In C23 (GCC 14+ defaults to -std=gnu23) bool is a built-in keyword, so the `typedef uint8_t bool;` in common_types.h is now a hard error ("two or more data types in declaration specifiers") when host build tools such as imageHdrScript are compiled with a modern host gcc.

Guard the typedef on __STDC_VERSION__ so it is kept for pre-C23 compilers and the PPE42 cross-toolchain, but skipped on C23+ where bool is already defined.